### PR TITLE
Replace row any types with typed record

### DIFF
--- a/src/components/DataUpload.tsx
+++ b/src/components/DataUpload.tsx
@@ -52,7 +52,7 @@ const DataUpload: React.FC<DataUploadProps> = ({ onDataLoaded }) => {
       const values = lines[i].split(',').map(v => v.trim().replace(/"/g, ''));
       if (values.length !== headers.length) continue;
 
-      const row: any = {};
+      const row: Record<string, string | number> = {};
       headers.forEach((header, index) => {
         const value = values[index];
         

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,7 +14,7 @@ const parseCSV = (csvText: string): CO2Data[] => {
   for (let i = 1; i < lines.length; i++) {
     const values = lines[i].split(',').map(v => v.trim().replace(/"/g, ''));
     if (values.length !== headers.length) continue;
-    const row: any = {};
+    const row: Record<string, string | number> = {};
     headers.forEach((header, idx) => {
       const value = values[idx];
       row[header] = isNaN(Number(value)) || value === '' ? value : Number(value);


### PR DESCRIPTION
## Summary
- use `Record<string, string | number>` instead of `any` when constructing CSV row objects

## Testing
- `npm run lint` *(fails: Unexpected any in interface, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686953fd1fec833393b693170363e5c1