### PR TITLE
Fix map container layout

### DIFF
--- a/src/components/MapVisualization.tsx
+++ b/src/components/MapVisualization.tsx
@@ -138,7 +138,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({ data, filters }) =>
         </p>
       </div>
       <div
-        className="relative w-full h-full"
+        className="relative w-full h-full min-h-[400px]"
         style={{ minHeight: Math.max(screenHeight - 120, 400) }}
       >
         <MapContainer


### PR DESCRIPTION
## Summary
- ensure the div wrapping `MapContainer` always maintains a minimum height
- keep `MapContainer` occupying full width and height of its wrapper

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686964f076e4833387f75e6706c7f9ad