### PR TITLE
Fix dataset fetch path

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -68,7 +68,7 @@ const Index = () => {
   useEffect(() => {
     const loadData = async () => {
       try {
-        const res = await fetch('/climatetrace_aggregated.csv');
+        const res = await fetch(`${import.meta.env.BASE_URL}climatetrace_aggregated.csv`);
         if (!res.ok) throw new Error('Failed to load data');
         const text = await res.text();
         const parsedData = parseCSV(text);


### PR DESCRIPTION
## Summary
- use `import.meta.env.BASE_URL` when loading default dataset

## Testing
- `bun run dev` *(checked with `curl` to ensure server and CSV return 200)*

------
https://chatgpt.com/codex/tasks/task_e_686964ef8c9c833389e486d7111db876