### PR TITLE
Fix startup crash with localStorage access

### DIFF
--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -53,13 +53,21 @@ export const useTranslation = () => {
 
   const changeLanguage = (lang: Language) => {
     setLanguage(lang);
-    localStorage.setItem('language', lang);
+    try {
+      localStorage.setItem('language', lang);
+    } catch (error) {
+      console.warn('Unable to store language preference:', error);
+    }
   };
 
   useEffect(() => {
-    const savedLang = localStorage.getItem('language') as Language;
-    if (savedLang && ['es', 'en'].includes(savedLang)) {
-      setLanguage(savedLang);
+    try {
+      const savedLang = localStorage.getItem('language') as Language;
+      if (savedLang && ['es', 'en'].includes(savedLang)) {
+        setLanguage(savedLang);
+      }
+    } catch (error) {
+      console.warn('Unable to access localStorage:', error);
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- handle `localStorage` access failures in `useTranslation`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686968dfded08333804069f5f6fd5a64