### PR TITLE
Fix map visibility during data load

### DIFF
--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -19,6 +19,8 @@ export interface FilterState {
   sector: string | null;
 }
 
+const ALL_VALUE = '__all__'
+
 const FilterPanel: React.FC<FilterPanelProps> = ({
   onFiltersChange,
   availableRegions,
@@ -58,15 +60,17 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
           <label className="block text-sm font-medium text-gray-700 mb-2">
             {t('filters.region')}
           </label>
-          <Select 
-            value={filters.region || ""} 
-            onValueChange={(value) => handleFilterChange('region', value || null)}
+          <Select
+            value={filters.region || ""}
+            onValueChange={(value) =>
+              handleFilterChange('region', value === ALL_VALUE ? null : value)
+            }
           >
             <SelectTrigger>
               <SelectValue placeholder={`${t('filters.region')}...`} />
             </SelectTrigger>
             <SelectContent className="bg-white z-50">
-              <SelectItem value="">Todas las regiones</SelectItem>
+              <SelectItem value={ALL_VALUE}>Todas las regiones</SelectItem>
               {availableRegions.map((region) => (
                 <SelectItem key={region} value={region}>
                   {region}
@@ -81,15 +85,18 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
           <label className="block text-sm font-medium text-gray-700 mb-2">
             {t('filters.year')}
           </label>
-          <Select 
-            value={filters.year?.toString() || ""} 
-            onValueChange={(value) => handleFilterChange('year', value ? parseInt(value) : null)}
+          <Select
+            value={filters.year?.toString() || ""}
+            onValueChange={(value) =>
+              handleFilterChange('year',
+                value === ALL_VALUE ? null : value ? parseInt(value) : null)
+            }
           >
             <SelectTrigger>
               <SelectValue placeholder={`${t('filters.year')}...`} />
             </SelectTrigger>
             <SelectContent className="bg-white z-50">
-              <SelectItem value="">Todos los años</SelectItem>
+              <SelectItem value={ALL_VALUE}>Todos los años</SelectItem>
               {availableYears.sort((a, b) => b - a).map((year) => (
                 <SelectItem key={year} value={year.toString()}>
                   {year}
@@ -104,15 +111,17 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
           <label className="block text-sm font-medium text-gray-700 mb-2">
             {t('filters.sector')}
           </label>
-          <Select 
-            value={filters.sector || ""} 
-            onValueChange={(value) => handleFilterChange('sector', value || null)}
+          <Select
+            value={filters.sector || ""}
+            onValueChange={(value) =>
+              handleFilterChange('sector', value === ALL_VALUE ? null : value)
+            }
           >
             <SelectTrigger>
               <SelectValue placeholder={`${t('filters.sector')}...`} />
             </SelectTrigger>
             <SelectContent className="bg-white z-50">
-              <SelectItem value="">Todos los sectores</SelectItem>
+              <SelectItem value={ALL_VALUE}>Todos los sectores</SelectItem>
               {availableSectors.map((sector) => (
                 <SelectItem key={sector} value={sector}>
                   {sector}

--- a/src/components/MapVisualization.tsx
+++ b/src/components/MapVisualization.tsx
@@ -10,6 +10,8 @@ import { sanitizeHtml, sanitizeString } from '../utils/security';
 interface MapVisualizationProps {
   data: CO2Data[];
   filters: FilterState;
+  isLoading?: boolean;
+  error?: string | null;
 }
 
 const ZoomListener: React.FC<{ onZoom: (z: number) => void }> = ({ onZoom }) => {
@@ -21,7 +23,12 @@ const ZoomListener: React.FC<{ onZoom: (z: number) => void }> = ({ onZoom }) => 
   return null;
 };
 
-const MapVisualization: React.FC<MapVisualizationProps> = ({ data, filters }) => {
+const MapVisualization: React.FC<MapVisualizationProps> = ({
+  data,
+  filters,
+  isLoading = false,
+  error = null,
+}) => {
   const { t } = useTranslation();
   const [zoom, setZoom] = useState(6);
   const [screenHeight, setScreenHeight] = useState<number>(typeof window !== 'undefined' ? window.innerHeight : 800);
@@ -212,10 +219,18 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({ data, filters }) =>
           </div>
         </div>
 
-        {filteredData.length === 0 && (
-          <div className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-90">
-            <div className="text-center">
-              <p className="text-gray-600">{sanitizeHtml(t('data.noData'))}</p>
+        {(isLoading || error || filteredData.length === 0) && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div className="bg-white bg-opacity-80 px-4 py-2 rounded">
+              <p className="text-gray-600 text-center">
+                {sanitizeHtml(
+                  isLoading
+                    ? t('data.loading')
+                    : error
+                    ? `${t('data.error')}: ${error}`
+                    : t('data.noData')
+                )}
+              </p>
             </div>
           </div>
         )}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -132,21 +132,12 @@ const Index = () => {
             availableYears={availableYears}
             availableSectors={availableSectors}
           />
-          {isLoading ? (
-            <div className="flex items-center justify-center h-full text-gray-600">
-              {t('data.loading')}
-            </div>
-          ) : error ? (
-            <div className="flex items-center justify-center h-full text-red-600">
-              {t('data.error')}: {error}
-            </div>
-          ) : data.length > 0 ? (
-            <MapVisualization data={data} filters={filters} />
-          ) : (
-            <div className="flex items-center justify-center h-full text-gray-600">
-              No hay datos disponibles
-            </div>
-          )}
+          <MapVisualization
+            data={data}
+            filters={filters}
+            isLoading={isLoading}
+            error={error}
+          />
         </main>
       </div>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- always render `MapVisualization` so map appears before data loads
- add `isLoading` and `error` props to `MapVisualization`
- show overlay messages without blocking map

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686970b8d8348333b9a44166dddd3175