### PR TITLE
Add translation keys for map legend

### DIFF
--- a/src/components/MapVisualization.tsx
+++ b/src/components/MapVisualization.tsx
@@ -185,15 +185,15 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
         <div className="space-y-1">
           <div className="flex items-center space-x-2">
             <div className="w-4 h-4 rounded-full bg-red-500" />
-            <span className="text-xs">Alta emisión</span>
+            <span className="text-xs">{sanitizeHtml(t('map.high'))}</span>
           </div>
           <div className="flex items-center space-x-2">
             <div className="w-4 h-4 rounded-full bg-yellow-500" />
-            <span className="text-xs">Media emisión</span>
+            <span className="text-xs">{sanitizeHtml(t('map.medium'))}</span>
           </div>
           <div className="flex items-center space-x-2">
             <div className="w-4 h-4 rounded-full bg-green-500" />
-            <span className="text-xs">Baja emisión</span>
+            <span className="text-xs">{sanitizeHtml(t('map.low'))}</span>
           </div>
         </div>
       </div>
@@ -201,7 +201,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
       {/* Total */}
       <div className="absolute top-4 right-4 z-[1200] bg-white p-3 rounded-lg shadow-lg">
         <div className="text-sm">
-          <div className="font-semibold">Total Emisiones</div>
+          <div className="font-semibold">{sanitizeHtml(t('map.total'))}</div>
           <div className="text-2xl font-bold text-green-600">
             {formatNumber(totalEmissions)} M
           </div>

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -36,6 +36,10 @@ const translations: Translations = {
   'map.title': { es: 'Mapa de Emisiones', en: 'Emissions Map' },
   'map.legend': { es: 'Leyenda', en: 'Legend' },
   'map.unit': { es: 'Mt CO₂', en: 'Mt CO₂' },
+  'map.high': { es: 'Alta emisión', en: 'High emission' },
+  'map.medium': { es: 'Media emisión', en: 'Medium emission' },
+  'map.low': { es: 'Baja emisión', en: 'Low emission' },
+  'map.total': { es: 'Total Emisiones', en: 'Total Emissions' },
   
   // Upload
   'upload.title': { es: 'Subir Archivo CSV', en: 'Upload CSV File' },


### PR DESCRIPTION
## Summary
- add translation entries for map legend labels and totals
- replace hard-coded labels with translations in `MapVisualization`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686986a620e483338d1d2bbb9007b530