### PR TITLE
Improve filter labels

### DIFF
--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState } from 'react';
 import { useTranslation } from '../hooks/useTranslation';
+import { humanizeLabel } from '@/utils/humanize';
 import { Filter } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -124,7 +125,7 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
               <SelectItem value={ALL_VALUE}>{t('filters.allSectors')}</SelectItem>
               {availableSectors.map((sector) => (
                 <SelectItem key={sector} value={sector}>
-                  {sector}
+                  {humanizeLabel(sector)}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/components/MapVisualization.tsx
+++ b/src/components/MapVisualization.tsx
@@ -5,6 +5,7 @@ import type { LatLngExpression } from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 
 import { useTranslation } from '../hooks/useTranslation';
+import { humanizeLabel } from '@/utils/humanize';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
@@ -156,7 +157,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
               <SelectContent className="bg-white z-50">
                 {availableMetrics.map(metric => (
                   <SelectItem key={metric} value={metric}>
-                    {metric}
+                    {humanizeLabel(metric)}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -237,7 +238,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
                     </h3>
                     {selectedMetrics.map(m => (
                       <div key={m} className="text-sm text-gray-600">
-                        <span className="font-medium">{m}:</span>{' '}
+                        <span className="font-medium">{humanizeLabel(m)}:</span>{' '}
                         {typeof item[m] === 'number'
                           ? (item[m] as number).toLocaleString()
                           : 'N/A'}{' '}
@@ -246,7 +247,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
                     ))}
                     {item.sector && (
                       <div className="text-sm text-gray-600">
-                        <span className="font-medium">Sector:</span> {item.sector}
+                        <span className="font-medium">Sector:</span> {humanizeLabel(item.sector)}
                       </div>
                     )}
                     {item.year && (

--- a/src/utils/humanize.ts
+++ b/src/utils/humanize.ts
@@ -1,0 +1,12 @@
+export const humanizeLabel = (label: string): string => {
+  if (!label) return label;
+  return label
+    .split(':')
+    .map(part =>
+      part
+        .split(/[-_]/)
+        .map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+        .join(' ')
+    )
+    .join(' - ');
+};


### PR DESCRIPTION
## Summary
- add helper for human friendly labels
- show humanized sector names in FilterPanel
- display humanized metric and sector names in MapVisualization

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869907f90608333803644342026a57d