### PR TITLE
Persist filter selections

### DIFF
--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from '../hooks/useTranslation';
 import { humanizeLabel } from '@/utils/humanize';
 import { Filter } from 'lucide-react';
@@ -8,6 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 interface FilterPanelProps {
+  filters: FilterState;
   onFiltersChange: (filters: FilterState) => void;
   availableRegions: string[];
   availableYears: number[];
@@ -23,27 +24,24 @@ export interface FilterState {
 const ALL_VALUE = '__all__'
 
 const FilterPanel: React.FC<FilterPanelProps> = ({
+  filters,
   onFiltersChange,
   availableRegions,
   availableYears,
   availableSectors
 }) => {
   const { t } = useTranslation();
-  const [filters, setFilters] = useState<FilterState>({
-    region: null,
-    year: null,
-    sector: null
-  });
 
-  const handleFilterChange = (key: keyof FilterState, value: string | number | null) => {
+  const handleFilterChange = (
+    key: keyof FilterState,
+    value: string | number | null,
+  ) => {
     const newFilters = { ...filters, [key]: value };
-    setFilters(newFilters);
     onFiltersChange(newFilters);
   };
 
   const resetFilters = () => {
     const resetState = { region: null, year: null, sector: null };
-    setFilters(resetState);
     onFiltersChange(resetState);
   };
 

--- a/src/components/MapVisualization.tsx
+++ b/src/components/MapVisualization.tsx
@@ -187,6 +187,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
           availableRegions={availableRegions}
           availableYears={availableYears}
           availableSectors={availableSectors}
+          filters={filters}
           onFiltersChange={onFiltersChange}
           onDataLoaded={onDataLoaded}
         />

--- a/src/components/MobileMenuSheet.tsx
+++ b/src/components/MobileMenuSheet.tsx
@@ -23,6 +23,7 @@ interface MobileMenuSheetProps {
   availableRegions: string[];
   availableYears: number[];
   availableSectors: string[];
+  filters: FilterState;
   onFiltersChange: (filters: FilterState) => void;
   onDataLoaded: (data: CO2Data[]) => void;
 }
@@ -35,6 +36,7 @@ const MobileMenuSheet: React.FC<MobileMenuSheetProps> = ({
   availableRegions,
   availableYears,
   availableSectors,
+  filters,
   onFiltersChange,
   onDataLoaded,
 }) => {
@@ -141,6 +143,7 @@ const MobileMenuSheet: React.FC<MobileMenuSheetProps> = ({
 
             {activeTab === 'filters' && (
               <FilterPanel
+                filters={filters}
                 onFiltersChange={onFiltersChange}
                 availableRegions={availableRegions}
                 availableYears={availableYears}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -112,10 +112,15 @@ const Index: React.FC = () => {
   const { t } = useTranslation();
 
   const [data, setData] = useState<CO2Data[]>([]);
-  const [filters, setFilters] = useState<FilterState>({
-    region: null,
-    year: null,
-    sector: null,
+  const [filters, setFilters] = useState<FilterState>(() => {
+    try {
+      const saved = localStorage.getItem('filters');
+      return saved
+        ? (JSON.parse(saved) as FilterState)
+        : { region: null, year: null, sector: null };
+    } catch {
+      return { region: null, year: null, sector: null };
+    }
   });
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -148,6 +153,14 @@ const Index: React.FC = () => {
       // ignore
     }
   }, [selectedMetrics]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('filters', JSON.stringify(filters));
+    } catch {
+      // ignore
+    }
+  }, [filters]);
 
   // Load default CSV on mount
   useEffect(() => {
@@ -270,6 +283,7 @@ const Index: React.FC = () => {
               </SheetTrigger>
               <SheetContent side="right" className="sm:w-80">
                 <FilterPanel
+                  filters={filters}
                   onFiltersChange={handleFiltersChange}
                   availableRegions={availableRegions}
                   availableYears={availableYears}


### PR DESCRIPTION
## Summary
- make `FilterPanel` controlled by parent
- persist filters to `localStorage`
- supply current filter state to filter UIs

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab1663d5083338f595cc91cd3d8d4