### PR TITLE
Show active filters in filter menu

### DIFF
--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from '../hooks/useTranslation';
 import { humanizeLabel } from '@/utils/humanize';
 import { Filter } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
@@ -54,6 +55,33 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
+        {/* Active Filters Summary */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            {t('filters.active')}
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {filters.region && (
+              <Badge variant="secondary">
+                {t('filters.region')}: {filters.region}
+              </Badge>
+            )}
+            {filters.year && (
+              <Badge variant="secondary">
+                {t('filters.year')}: {filters.year}
+              </Badge>
+            )}
+            {filters.sector && (
+              <Badge variant="secondary">
+                {t('filters.sector')}: {humanizeLabel(filters.sector)}
+              </Badge>
+            )}
+            {!filters.region && !filters.year && !filters.sector && (
+              <span className="text-sm text-gray-500">{t('filters.none')}</span>
+            )}
+          </div>
+        </div>
+
         {/* Region Filter */}
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-2">

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -29,6 +29,8 @@ const translations: Translations = {
   'filters.allRegions': { es: 'Todas las regiones', en: 'All regions' },
   'filters.allYears': { es: 'Todos los años', en: 'All years' },
   'filters.allSectors': { es: 'Todos los sectores', en: 'All sectors' },
+  'filters.active': { es: 'Filtros activos', en: 'Active filters' },
+  'filters.none': { es: 'Ninguno', en: 'None' },
   
   // Data
   'data.loading': { es: 'Cargando datos...', en: 'Loading data...' },


### PR DESCRIPTION
## Summary
- show currently applied filters at the top of the FilterPanel
- add translations for active filters labels

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686abc6017248333b13e81782890ee56