### PR TITLE
Add translation keys and refactor labels

### DIFF
--- a/src/components/MapVisualization.tsx
+++ b/src/components/MapVisualization.tsx
@@ -222,7 +222,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
                 onValueChange={value => onMetricsChange([value])}
               >
                 <SelectTrigger>
-                  <SelectValue placeholder="Select metric…" />
+                  <SelectValue placeholder={t('map.selectMetricPlaceholder')} />
                 </SelectTrigger>
                 <SelectContent className="bg-white z-[1400]">
                   {availableMetrics.map(metric => (
@@ -239,7 +239,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
               <div className="flex items-center justify-between">
                 <span className="text-sm text-gray-600">{t('map.total')}:</span>
                 <Badge variant="secondary">
-                  {aggregatedData.length} regions
+                  {aggregatedData.length} {t('map.regionsLabel')}
                 </Badge>
               </div>
             </div>
@@ -325,19 +325,19 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
                         <span className="font-medium">{humanizeLabel(m)}:</span>{' '}
                         {typeof item[m] === 'number'
                           ? (item[m] as number).toLocaleString()
-                          : 'N/A'}{' '}
+                          : t('map.na')}{' '}
                         {t('map.unit')}
                       </div>
                     ))}
                     {item.sector && (
                       <div className="text-sm text-gray-600">
-                        <span className="font-medium">Sector:</span>{' '}
+                        <span className="font-medium">{t('filters.sector')}:</span>{' '}
                         {item.sector}
                       </div>
                     )}
                     {item.year && (
                       <div className="text-sm text-gray-600">
-                        <span className="font-medium">Year:</span> {item.year}
+                        <span className="font-medium">{t('filters.year')}:</span> {item.year}
                       </div>
                     )}
                   </div>

--- a/src/components/MobileMenuSheet.tsx
+++ b/src/components/MobileMenuSheet.tsx
@@ -70,15 +70,15 @@ const MobileMenuSheet: React.FC<MobileMenuSheetProps> = ({
         <div className="flex flex-col h-full">
           {/* Header */}
           <div className="p-4 border-b">
-            <h2 className="text-lg font-semibold">Map Controls</h2>
+            <h2 className="text-lg font-semibold">{t('menu.mapControls')}</h2>
           </div>
 
           {/* Tab Navigation */}
           <div className="flex gap-1 p-2 border-b">
-            <TabButton id="metrics" icon={BarChart3} label="Metrics" />
-            <TabButton id="legend" icon={Info} label="Legend" />
-            <TabButton id="upload" icon={Upload} label="Upload" />
-            <TabButton id="filters" icon={Filter} label="Filters" />
+            <TabButton id="metrics" icon={BarChart3} label={t('menu.metrics')} />
+            <TabButton id="legend" icon={Info} label={t('menu.legend')} />
+            <TabButton id="upload" icon={Upload} label={t('menu.upload')} />
+            <TabButton id="filters" icon={Filter} label={t('menu.filters')} />
           </div>
 
           {/* Content Area */}
@@ -94,7 +94,7 @@ const MobileMenuSheet: React.FC<MobileMenuSheetProps> = ({
                     onValueChange={value => onMetricsChange([value])}
                   >
                     <SelectTrigger>
-                      <SelectValue placeholder="Select metric…" />
+                      <SelectValue placeholder={t('map.selectMetricPlaceholder')} />
                     </SelectTrigger>
                     <SelectContent className="bg-white">
                       {availableMetrics.map(metric => (
@@ -111,7 +111,7 @@ const MobileMenuSheet: React.FC<MobileMenuSheetProps> = ({
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-gray-600">{t('map.total')}:</span>
                   <Badge variant="secondary">
-                    {aggregatedData.length} regions
+                    {aggregatedData.length} {t('map.regionsLabel')}
                   </Badge>
                 </div>
               </div>

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -46,6 +46,16 @@ const translations: Translations = {
   'map.low': { es: 'Baja emisión', en: 'Low emission' },
   'map.total': { es: 'Total Emisiones', en: 'Total Emissions' },
   'map.selectMetrics': { es: 'Seleccionar métricas', en: 'Select metrics' },
+  'map.selectMetricPlaceholder': { es: 'Seleccionar métrica…', en: 'Select metric…' },
+  'map.regionsLabel': { es: 'regiones', en: 'regions' },
+  'map.na': { es: 'N/D', en: 'N/A' },
+
+  // Mobile/Side menu labels
+  'menu.mapControls': { es: 'Controles del mapa', en: 'Map Controls' },
+  'menu.metrics': { es: 'Métricas', en: 'Metrics' },
+  'menu.legend': { es: 'Leyenda', en: 'Legend' },
+  'menu.upload': { es: 'Cargar', en: 'Upload' },
+  'menu.filters': { es: 'Filtros', en: 'Filters' },
   
   // Upload
   'upload.title': { es: 'Subir Archivo CSV', en: 'Upload CSV File' },
@@ -80,6 +90,10 @@ const translations: Translations = {
   },
   'errorBoundary.reload': { es: 'Recargar página', en: 'Reload page' },
   'errorBoundary.retry': { es: 'Intentar de nuevo', en: 'Try again' },
+
+  // Not Found page
+  'notFound.oops': { es: '¡Vaya! Página no encontrada', en: 'Oops! Page not found' },
+  'notFound.returnHome': { es: 'Volver al inicio', en: 'Return to Home' },
 };
 
 export const useTranslation = () => {

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,8 +1,10 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { useTranslation } from "../hooks/useTranslation";
 
 const NotFound = () => {
   const location = useLocation();
+  const { t } = useTranslation();
 
   useEffect(() => {
     console.error(
@@ -15,9 +17,9 @@ const NotFound = () => {
     <div className="min-h-screen flex items-center justify-center bg-gray-100">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
+        <p className="text-xl text-gray-600 mb-4">{t('notFound.oops')}</p>
         <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
+          {t('notFound.returnHome')}
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add translation terms for map menus, placeholders, and not found page
- use `t()` to localize labels in `MobileMenuSheet`
- localize a few map popup labels and placeholder text
- internationalize the 404 page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ae528694c8333bc184a03eb500f90