### PR TITLE
Fix filter default and popup visibility

### DIFF
--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -88,7 +88,7 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
             {t('filters.region')}
           </label>
           <Select
-            value={filters.region || ""}
+            value={filters.region ?? ALL_VALUE}
             onValueChange={(value) =>
               handleFilterChange('region', value === ALL_VALUE ? null : value)
             }
@@ -113,10 +113,16 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
             {t('filters.year')}
           </label>
           <Select
-            value={filters.year?.toString() || ""}
+            value={
+              filters.year !== null && filters.year !== undefined
+                ? filters.year.toString()
+                : ALL_VALUE
+            }
             onValueChange={(value) =>
-              handleFilterChange('year',
-                value === ALL_VALUE ? null : value ? parseInt(value) : null)
+              handleFilterChange(
+                'year',
+                value === ALL_VALUE ? null : value ? parseInt(value) : null
+              )
             }
           >
             <SelectTrigger>
@@ -139,7 +145,7 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
             {t('filters.sector')}
           </label>
           <Select
-            value={filters.sector || ""}
+            value={filters.sector ?? ALL_VALUE}
             onValueChange={(value) =>
               handleFilterChange('sector', value === ALL_VALUE ? null : value)
             }

--- a/src/components/MapVisualization.tsx
+++ b/src/components/MapVisualization.tsx
@@ -177,7 +177,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
       style={{ height: 'calc(100vh - 4rem)' }}
     >
       {/* Mobile Menu - Only visible on mobile */}
-      <div className="md:hidden absolute top-4 left-4 z-[1000]">
+      <div className="md:hidden absolute top-4 left-4 z-[500]">
         <MobileMenuSheet
           selectedMetrics={selectedMetrics}
           availableMetrics={availableMetrics}
@@ -193,7 +193,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
       </div>
 
       {/* Desktop Controls Panel - Hidden on mobile */}
-      <Card className="hidden md:block absolute top-4 left-4 z-[1000] w-80 bg-white/95 backdrop-blur-sm">
+      <Card className="hidden md:block absolute top-4 left-4 z-[500] w-80 bg-white/95 backdrop-blur-sm">
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center justify-between text-lg">
             <div className="flex items-center space-x-2">
@@ -247,7 +247,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
       </Card>
 
       {/* Desktop Legend Panel - Hidden on mobile */}
-      <Card className="hidden md:block absolute top-4 left-[22rem] z-[1000] w-48 bg-white/95 backdrop-blur-sm">
+      <Card className="hidden md:block absolute top-4 left-[22rem] z-[500] w-48 bg-white/95 backdrop-blur-sm">
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center justify-between text-sm">
             <span>{t('map.legend')}</span>
@@ -348,7 +348,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
 
       {/* Status Message */}
       {statusMessage && (
-        <div className="absolute bottom-4 left-4 z-[1000]">
+        <div className="absolute bottom-4 left-4 z-[500]">
           <Badge variant="outline" className="bg-white/95 backdrop-blur-sm">
             {statusMessage}
           </Badge>


### PR DESCRIPTION
## Summary
- show `All` options as selected in filter panel when no filter is chosen
- reduce z-index of overlay panels so Leaflet popups remain visible

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686b7c1041f88333bf99ebb64f11d864