### PR TITLE
Show Spain total outside map markers

### DIFF
--- a/src/context/TranslationContext.tsx
+++ b/src/context/TranslationContext.tsx
@@ -50,6 +50,10 @@ const translations: Translations = {
   'map.selectMetrics': { es: 'Seleccionar métricas', en: 'Select metrics' },
   'map.selectMetricPlaceholder': { es: 'Seleccionar métrica…', en: 'Select metric…' },
   'map.regionsLabel': { es: 'regiones', en: 'regions' },
+  'map.spainTotal': {
+    es: 'Total España: {value} {unit}',
+    en: 'Spain total: {value} {unit}',
+  },
   'map.na': { es: 'N/D', en: 'N/A' },
 
   // Mobile/Side menu labels


### PR DESCRIPTION
## Summary
- compute Spain CO₂ totals separately from regions
- exclude Spain records from marker sizing and colouring
- show Spain total in the desktop legend
- display Spain total next to the mobile menu
- add translation key for the Spain total message

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686b8d52aa888333a5b59d428dffc693