### PR TITLE
Display emissions in billions

### DIFF
--- a/src/components/MapVisualization.tsx
+++ b/src/components/MapVisualization.tsx
@@ -7,7 +7,7 @@ import type { LatLngExpression } from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 
 import { useTranslation } from '../hooks/useTranslation';
-import { humanizeLabel } from '@/utils/humanize';
+import { humanizeLabel, formatBillions } from '@/utils/humanize';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
@@ -233,7 +233,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
         <div className="md:hidden absolute top-4 left-16 right-4 z-[500]">
           <Badge variant="outline" className="bg-white/95 backdrop-blur-sm">
             {t('map.spainTotal', {
-              value: spainTotal.toLocaleString(),
+              value: formatBillions(spainTotal),
               unit: t('map.unit'),
             })}
           </Badge>
@@ -327,7 +327,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
             {spainTotal > 0 && (
               <div className="pt-2 text-xs text-gray-700 border-t mt-2">
                 {t('map.spainTotal', {
-                  value: spainTotal.toLocaleString(),
+                  value: formatBillions(spainTotal),
                   unit: t('map.unit'),
                 })}
               </div>
@@ -379,7 +379,7 @@ const MapVisualization: React.FC<MapVisualizationProps> = ({
                       <div key={m} className="text-sm text-gray-600">
                         <span className="font-medium">{humanizeLabel(m)}:</span>{' '}
                         {typeof item[m] === 'number'
-                          ? (item[m] as number).toLocaleString()
+                          ? formatBillions(item[m] as number)
                           : t('map.na')}{' '}
                         {t('map.unit')}
                       </div>

--- a/src/context/TranslationContext.tsx
+++ b/src/context/TranslationContext.tsx
@@ -42,7 +42,7 @@ const translations: Translations = {
   // Map
   'map.title': { es: 'Mapa de Emisiones', en: 'Emissions Map' },
   'map.legend': { es: 'Leyenda', en: 'Legend' },
-  'map.unit': { es: 'Mt CO₂', en: 'Mt CO₂' },
+  'map.unit': { es: 'billones t CO₂', en: 'bn t CO₂' },
   'map.high': { es: 'Alta emisión', en: 'High emission' },
   'map.medium': { es: 'Media emisión', en: 'Medium emission' },
   'map.low': { es: 'Baja emisión', en: 'Low emission' },

--- a/src/utils/humanize.ts
+++ b/src/utils/humanize.ts
@@ -10,3 +10,13 @@ export const humanizeLabel = (label: string): string => {
     )
     .join(' - ');
 };
+
+export const toBillions = (value: number): number => value / 1_000_000_000_000;
+
+export const formatBillions = (
+  value: number,
+  fractionDigits = 3
+): string =>
+  toBillions(value).toLocaleString(undefined, {
+    maximumFractionDigits: fractionDigits,
+  });


### PR DESCRIPTION
## Summary
- show emission values in billions instead of previous units
- update translations for new unit
- utility helpers for formatting numbers in billions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b926e88b48333986eaadb783da057